### PR TITLE
Apply clippy suggestions

### DIFF
--- a/src/facts.rs
+++ b/src/facts.rs
@@ -43,22 +43,22 @@ pub const GF2561D_255_COSETS: &[&[usize]] = &[
     &[119, 238, 221, 187],
     &[127, 254, 253, 251, 247, 239, 223, 191],
 ];
-pub const GF2561D_SUB_2_NORMAL_BASIS: [GF2561D; 2] = [GF2561D(0b11010110), GF2561D(0b11010111)];
+pub const GF2561D_SUB_2_NORMAL_BASIS: [GF2561D; 2] = [GF2561D(0b1101_0110), GF2561D(0b1101_0111)];
 pub const GF2561D_SUB_4_NORMAL_BASIS: [GF2561D; 4] = [
-    GF2561D(0b00001010),
-    GF2561D(0b01000100),
-    GF2561D(0b11011101),
-    GF2561D(0b10010010),
+    GF2561D(0b0000_1010),
+    GF2561D(0b0100_0100),
+    GF2561D(0b1101_1101),
+    GF2561D(0b1001_0010),
 ];
 pub const GF2561D_SUB_8_NORMAL_BASIS: [GF2561D; 8] = [
-    GF2561D(0b11100111), // alpha^(2^0)
-    GF2561D(0b10111111), // alpha^(2^1)
-    GF2561D(0b00101111), // alpha^(2^2)
-    GF2561D(0b00100001), // alpha^(2^3)
-    GF2561D(0b01110101), // alpha^(2^4)
-    GF2561D(0b10110101), // alpha^(2^5)
-    GF2561D(0b01101011), // alpha^(2^6)
-    GF2561D(0b11111100), // alpha^(2^7)
+    GF2561D(0b1110_0111), // alpha^(2^0)
+    GF2561D(0b1011_1111), // alpha^(2^1)
+    GF2561D(0b0010_1111), // alpha^(2^2)
+    GF2561D(0b0010_0001), // alpha^(2^3)
+    GF2561D(0b0111_0101), // alpha^(2^4)
+    GF2561D(0b1011_0101), // alpha^(2^5)
+    GF2561D(0b0110_1011), // alpha^(2^6)
+    GF2561D(0b1111_1100), // alpha^(2^7)
 ];
 pub const GF2561DG2_3_ASSOC_TABLE: [[u8; 3]; 3] = [[1, 1, 1], [1, 1, 0], [1, 0, 1]];
 pub const GF2561DG2_5_ASSOC_TABLE: [[u8; 5]; 5] = [

--- a/src/field.rs
+++ b/src/field.rs
@@ -21,19 +21,19 @@ pub trait FiniteField: alga::general::Field {
 }
 
 pub trait FinitelyGenerated<G> {
-    const GENERATOR: Self;
+    fn generator() -> Self;
 }
 
-pub const GF2561D_NORMAL_BASIS: GF2561D = GF2561D(0b11100111);
+pub const GF2561D_NORMAL_BASIS: GF2561D = GF2561D(0b1110_0111);
 pub const GF2561D_NORMAL_BASIS_SET: &[GF2561D] = &[
-    GF2561D(0b11100111), // alpha^(2^0)
-    GF2561D(0b10111111), // alpha^(2^1)
-    GF2561D(0b00101111), // alpha^(2^2)
-    GF2561D(0b00100001), // alpha^(2^3)
-    GF2561D(0b01110101), // alpha^(2^4)
-    GF2561D(0b10110101), // alpha^(2^5)
-    GF2561D(0b01101011), // alpha^(2^6)
-    GF2561D(0b11111100), // alpha^(2^7)
+    GF2561D(0b1110_0111), // alpha^(2^0)
+    GF2561D(0b1011_1111), // alpha^(2^1)
+    GF2561D(0b0010_1111), // alpha^(2^2)
+    GF2561D(0b0010_0001), // alpha^(2^3)
+    GF2561D(0b0111_0101), // alpha^(2^4)
+    GF2561D(0b1011_0101), // alpha^(2^5)
+    GF2561D(0b0110_1011), // alpha^(2^6)
+    GF2561D(0b1111_1100), // alpha^(2^7)
 ];
 
 pub trait ArbitraryElement {
@@ -93,7 +93,9 @@ impl Display for F2 {
 }
 
 impl FinitelyGenerated<GF2561DG2> for GF2561D {
-    const GENERATOR: Self = GF2561D(2);
+    fn generator() -> GF2561D {
+        GF2561D(2)
+    }
 }
 
 impl ArbitraryElement for GF2561D {

--- a/src/fourier.rs
+++ b/src/fourier.rs
@@ -140,7 +140,7 @@ where
     assert_eq!(cyclotomic_cosets.len(), conv_bilinear_algos.len());
     assert_eq!(cyclotomic_cosets.len(), normal_basis.len());
     let convs: Vec<_> = conv_bilinear_algos
-        .into_iter()
+        .iter()
         .zip(normal_basis)
         .zip(cyclotomic_cosets.iter().map(|c| c.len()))
         .map(|((algo, basis), size)| {
@@ -174,77 +174,62 @@ where
     }
 }
 
-pub const GF2561DG2_UNITY_ROOT: UnityRoot<GF2561D> = UnityRoot {
-    order: 255,
-    root: <GF2561D as FinitelyGenerated<GF2561DG2>>::GENERATOR,
-};
+type GF2561DFFTOP = Pin<Arc<dyn Send + Sync + Fn(Vec<GF2561D>) -> Vec<GF2561D>>>;
 
 lazy_static! {
-    pub static ref GF2561DG2_3_COSETS_CONV: Vec<Vec<usize>> = {
-        crate::facts::GF2561D_3_COSETS
-            .into_iter()
-            .map(|v| v.to_vec())
-            .collect()
+    pub static ref GF2561DG2_UNITY_ROOT: UnityRoot<GF2561D> = UnityRoot {
+        order: 255,
+        root: <GF2561D as FinitelyGenerated<GF2561DG2>>::generator(),
     };
-    pub static ref GF2561DG2_5_COSETS_CONV: Vec<Vec<usize>> = {
-        crate::facts::GF2561D_5_COSETS
-            .into_iter()
-            .map(|v| v.to_vec())
-            .collect()
-    };
-    pub static ref GF2561DG2_17_COSETS_CONV: Vec<Vec<usize>> = {
-        crate::facts::GF2561D_17_COSETS
-            .into_iter()
-            .map(|v| v.to_vec())
-            .collect()
-    };
-    pub static ref GF2561DG2_255_COSETS_CONV: Vec<Vec<usize>> = {
-        crate::facts::GF2561D_255_COSETS
-            .into_iter()
-            .map(|v| v.to_vec())
-            .collect()
-    };
-    pub static ref GF2561DG2_3_ASSOC_CONV: Array2<F2> = {
-        Array2::from_shape_vec(
-            (3, 3),
-            crate::facts::GF2561DG2_3_ASSOC_TABLE
-                .into_iter()
-                .flat_map(|v| v.into_iter().map(|x| F2(*x)))
-                .collect(),
-        )
-        .expect("shape should be correct")
-    };
-    pub static ref GF2561DG2_5_ASSOC_CONV: Array2<F2> = {
-        Array2::from_shape_vec(
-            (5, 5),
-            crate::facts::GF2561DG2_5_ASSOC_TABLE
-                .into_iter()
-                .flat_map(|v| v.into_iter().map(|x| F2(*x)))
-                .collect(),
-        )
-        .expect("shape should be correct")
-    };
-    pub static ref GF2561DG2_17_ASSOC_CONV: Array2<F2> = {
-        Array2::from_shape_vec(
-            (17, 17),
-            crate::facts::GF2561DG2_17_ASSOC_TABLE
-                .into_iter()
-                .flat_map(|v| v.into_iter().map(|x| F2(*x)))
-                .collect(),
-        )
-        .expect("shape should be correct")
-    };
-    pub static ref GF2561DG2_255_ASSOC_CONV: Array2<F2> = {
-        Array2::from_shape_vec(
-            (255, 255),
-            crate::facts::GF2561DG2_255_ASSOC_TABLE
-                .into_iter()
-                .flat_map(|v| v.into_iter().map(|x| F2(*x)))
-                .collect(),
-        )
-        .expect("shape should be correct")
-    };
-    static ref GF2561D_3_FFT: Pin<Arc<dyn Send + Sync + Fn(Vec<GF2561D>) -> Vec<GF2561D>>> = {
+    pub static ref GF2561DG2_3_COSETS_CONV: Vec<Vec<usize>> = crate::facts::GF2561D_3_COSETS
+        .iter()
+        .map(|v| v.to_vec())
+        .collect();
+    pub static ref GF2561DG2_5_COSETS_CONV: Vec<Vec<usize>> = crate::facts::GF2561D_5_COSETS
+        .iter()
+        .map(|v| v.to_vec())
+        .collect();
+    pub static ref GF2561DG2_17_COSETS_CONV: Vec<Vec<usize>> = crate::facts::GF2561D_17_COSETS
+        .iter()
+        .map(|v| v.to_vec())
+        .collect();
+    pub static ref GF2561DG2_255_COSETS_CONV: Vec<Vec<usize>> = crate::facts::GF2561D_255_COSETS
+        .iter()
+        .map(|v| v.to_vec())
+        .collect();
+    pub static ref GF2561DG2_3_ASSOC_CONV: Array2<F2> = Array2::from_shape_vec(
+        (3, 3),
+        crate::facts::GF2561DG2_3_ASSOC_TABLE
+            .iter()
+            .flat_map(|v| v.iter().map(|&x| F2(x)))
+            .collect(),
+    )
+    .expect("shape should be correct");
+    pub static ref GF2561DG2_5_ASSOC_CONV: Array2<F2> = Array2::from_shape_vec(
+        (5, 5),
+        crate::facts::GF2561DG2_5_ASSOC_TABLE
+            .iter()
+            .flat_map(|v| v.iter().map(|&x| F2(x)))
+            .collect(),
+    )
+    .expect("shape should be correct");
+    pub static ref GF2561DG2_17_ASSOC_CONV: Array2<F2> = Array2::from_shape_vec(
+        (17, 17),
+        crate::facts::GF2561DG2_17_ASSOC_TABLE
+            .iter()
+            .flat_map(|v| v.iter().map(|&x| F2(x)))
+            .collect(),
+    )
+    .expect("shape should be correct");
+    pub static ref GF2561DG2_255_ASSOC_CONV: Array2<F2> = Array2::from_shape_vec(
+        (255, 255),
+        crate::facts::GF2561DG2_255_ASSOC_TABLE
+            .iter()
+            .flat_map(|v| v.iter().map(|&x| F2(x)))
+            .collect(),
+    )
+    .expect("shape should be correct");
+    static ref GF2561D_3_FFT: GF2561DFFTOP = {
         let assoc = GF2561DG2_3_ASSOC_CONV.clone();
         let cosets = GF2561DG2_3_COSETS_CONV.clone();
         let basis: Vec<_> = cosets
@@ -261,7 +246,7 @@ lazy_static! {
         let algos: Vec<_> = algos.iter().map(std::convert::identity).collect();
         Arc::pin(conv(assoc, cosets, &algos, &basis))
     };
-    static ref GF2561D_5_FFT: Pin<Arc<dyn Send + Sync + Fn(Vec<GF2561D>) -> Vec<GF2561D>>> = {
+    static ref GF2561D_5_FFT: GF2561DFFTOP = {
         let assoc = GF2561DG2_5_ASSOC_CONV.clone();
         let cosets = GF2561DG2_5_COSETS_CONV.clone();
         let basis: Vec<_> = cosets
@@ -278,7 +263,7 @@ lazy_static! {
         let algos: Vec<_> = algos.iter().map(std::convert::identity).collect();
         Arc::pin(conv(assoc, cosets, &algos, &basis))
     };
-    static ref GF2561D_17_FFT: Pin<Arc<dyn Send + Sync + Fn(Vec<GF2561D>) -> Vec<GF2561D>>> = {
+    static ref GF2561D_17_FFT: GF2561DFFTOP = {
         let assoc = GF2561DG2_17_ASSOC_CONV.clone();
         let cosets = GF2561DG2_17_COSETS_CONV.clone();
         let basis: Vec<_> = cosets
@@ -295,22 +280,19 @@ lazy_static! {
         let algos: Vec<_> = algos.iter().map(std::convert::identity).collect();
         Arc::pin(conv(assoc, cosets, &algos, &basis))
     };
-    pub static ref GF2561DG2_255_FFT: Pin<Arc<dyn Send + Sync + Fn(Vec<GF2561D>) -> Vec<GF2561D>>> = {
-        let root = GF2561DG2_UNITY_ROOT;
-        Arc::pin(cooley_tukey(
-            15,
-            17,
-            root.clone(),
-            cooley_tukey(
-                3,
-                5,
-                root.subgroup(15),
-                |x| GF2561D_3_FFT(x),
-                |x| GF2561D_5_FFT(x),
-            ),
-            |x| GF2561D_17_FFT(x),
-        ))
-    };
+    pub static ref GF2561DG2_255_FFT: GF2561DFFTOP = Arc::pin(cooley_tukey(
+        15,
+        17,
+        GF2561DG2_UNITY_ROOT.clone(),
+        cooley_tukey(
+            3,
+            5,
+            GF2561DG2_UNITY_ROOT.clone().subgroup(15),
+            |x| GF2561D_3_FFT(x),
+            |x| GF2561D_5_FFT(x),
+        ),
+        |x| GF2561D_17_FFT(x),
+    ));
 }
 
 #[derive(Clone)]
@@ -462,7 +444,7 @@ mod tests {
             map.insert(8, crate::facts::GF2561D_SUB_8_NORMAL_BASIS.to_vec());
             map
         };
-        let gamma = GF2561DG2_UNITY_ROOT.subgroup(order).root;
+        let gamma = GF2561DG2_UNITY_ROOT.clone().subgroup(order).root;
         let mut assoc = vec![];
         for j in 0..order {
             let gamma = pow(gamma, j);
@@ -508,22 +490,14 @@ mod tests {
             let algos: Vec<_> = algos.iter().map(std::convert::identity).collect();
             Arc::pin(conv(assoc, cosets, &algos, &basis))
         };
-        static ref GF2561D_3_NAIVE_FFT: Pin<Arc<dyn Send + Sync + Fn(Vec<GF2561D>) -> Vec<GF2561D>>> = {
-            let root = GF2561DG2_UNITY_ROOT.subgroup(3);
-            Arc::pin(naive(root))
-        };
-        static ref GF2561D_5_NAIVE_FFT: Pin<Arc<dyn Send + Sync + Fn(Vec<GF2561D>) -> Vec<GF2561D>>> = {
-            let root = GF2561DG2_UNITY_ROOT.subgroup(5);
-            Arc::pin(naive(root))
-        };
-        static ref GF2561D_17_NAIVE_FFT: Pin<Arc<dyn Send + Sync + Fn(Vec<GF2561D>) -> Vec<GF2561D>>> = {
-            let root = GF2561DG2_UNITY_ROOT.subgroup(17);
-            Arc::pin(naive(root))
-        };
-        static ref GF2561D_255_NAIVE_FFT: Pin<Arc<dyn Send + Sync + Fn(Vec<GF2561D>) -> Vec<GF2561D>>> = {
-            let root = GF2561DG2_UNITY_ROOT;
-            Arc::pin(naive(root))
-        };
+        static ref GF2561D_3_NAIVE_FFT: Pin<Arc<dyn Send + Sync + Fn(Vec<GF2561D>) -> Vec<GF2561D>>> =
+            Arc::pin(naive(GF2561DG2_UNITY_ROOT.clone().subgroup(3)));
+        static ref GF2561D_5_NAIVE_FFT: Pin<Arc<dyn Send + Sync + Fn(Vec<GF2561D>) -> Vec<GF2561D>>> =
+            Arc::pin(naive(GF2561DG2_UNITY_ROOT.clone().subgroup(5)));
+        static ref GF2561D_17_NAIVE_FFT: Pin<Arc<dyn Send + Sync + Fn(Vec<GF2561D>) -> Vec<GF2561D>>> =
+            Arc::pin(naive(GF2561DG2_UNITY_ROOT.clone().subgroup(17)));
+        static ref GF2561D_255_NAIVE_FFT: Pin<Arc<dyn Send + Sync + Fn(Vec<GF2561D>) -> Vec<GF2561D>>> =
+            Arc::pin(naive(GF2561DG2_UNITY_ROOT.clone()));
     }
 
     #[test]

--- a/src/lfsr.rs
+++ b/src/lfsr.rs
@@ -9,6 +9,7 @@ pub struct LFSR<F> {
 }
 
 /// Berlekamp Massey
+#[allow(clippy::many_single_char_names)] // REASON: match up with symbols in the textbook
 pub fn berlekamp_massey<F>(s: &[F]) -> LFSR<F>
 where
     F: Field + Clone,
@@ -109,7 +110,7 @@ where
     let UnityRoot { root, order: max } = root;
     let n = s.len();
     assert!(n <= max);
-    let mut s_poly = Polynomial::new(s.into_iter().cloned());
+    let mut s_poly = Polynomial::new(s.iter().cloned());
     for &erasure in erasure {
         assert!(erasure < max);
         if erasure < n {
@@ -123,7 +124,7 @@ where
 mod tests {
     use super::*;
 
-    use crate::{field::GF2561D, tests::F7};
+    use crate::tests::F7;
 
     #[quickcheck]
     fn berlekamp_massey_tests(s: Vec<F7>) {


### PR DESCRIPTION
Some clippy suggestions are taken to make the crate compatible with future Rust versions. A notable example is to switch to `.iter()` from `.into_iter()` with `array`s and `slice`s.