### PR TITLE
Allow access to bits in shared key

### DIFF
--- a/src/lattice.rs
+++ b/src/lattice.rs
@@ -749,6 +749,13 @@ impl<'a> Deserialize<'a> for Reconciliator {
 #[derive(Clone)]
 pub struct SharedKey([bool; KEY_SIZE]);
 
+impl Deref for SharedKey {
+    type Target = [bool];
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
 impl std::cmp::PartialEq for SharedKey {
     fn eq(&self, other: &Self) -> bool {
         let mut r = true;


### PR DESCRIPTION
This is important, so that we can use the shared key in a meaningful way