### PR TITLE
Improve mceliece keygen success rate

### DIFF
--- a/src/bin/mceliece_gen.rs
+++ b/src/bin/mceliece_gen.rs
@@ -32,8 +32,9 @@ fn main() -> Result<(), Error> {
     let opt = Opt::from_args();
     let n = 6960;
     let t = 94;
-    let (enc, dec) =
-        generate::<GF65536N, GF65536NTower, GF65536NPreparedMultipointEvalVZG, _>(&mut OsRng, t, n);
+    let (enc, dec) = generate::<GF65536N, GF65536NTower, GF65536NPreparedMultipointEvalVZG, _>(
+        &mut OsRng, t, n, 32, 64,
+    );
     write!(
         File::create(opt.pubkey)?,
         "{}",

--- a/tests/goppa.rs
+++ b/tests/goppa.rs
@@ -12,8 +12,9 @@ fn encode_decode_large() {
     let n = 6960;
     let t = 94;
     let u = rand::distributions::uniform::Uniform::from(0..n);
-    let (enc, dec) =
-        generate::<GF65536N, GF65536NTower, GF65536NPreparedMultipointEvalVZG, _>(&mut OsRng, t, n);
+    let (enc, dec) = generate::<GF65536N, GF65536NTower, GF65536NPreparedMultipointEvalVZG, _>(
+        &mut OsRng, t, n, 32, 64,
+    );
     let dec = BinaryGoppaDecoder::from_decoder(dec);
     for _ in 0..2 {
         let mut x = vec![0; n];


### PR DESCRIPTION
This PR improve Classical McEliece keygen efficiency, by permuting the random points for a admissible parity matrix.