### PR TITLE
Allow (de)serialization of McEliece keys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 alga = "0.9.1"
 alga_derive = "0.9.1"
-blake2 = "0.8.1"
 cached = "0.11.0"
 crossbeam = "0.7.3"
 derive_more = "0.15.0"
@@ -41,6 +40,7 @@ features = ["rayon"]
 
 [dev-dependencies]
 approx = "0.3.0"
+blake2 = "0.8.1"
 quickcheck = "0.8.0"
 quickcheck_macros = "0.8.0"
 rand_chacha = "0.2.1"
@@ -48,6 +48,3 @@ rand_chacha = "0.2.1"
 [dev-dependencies.phf]
 version = "0.8"
 features = ["macros"]
-
-[profile.release]
-debug = true

--- a/src/mceliece.rs
+++ b/src/mceliece.rs
@@ -13,6 +13,7 @@ use crate::{
     ser::{bitvec_to_u8, u8_to_bitvec},
 };
 
+#[derive(Serialize, Deserialize)]
 pub struct McElieceKEM65536PublicKey {
     key: GoppaEncoder<F2, GF65536NTower>,
 }
@@ -29,7 +30,17 @@ pub struct McElieceCiphertext<H> {
     pub c_0: Vec<u8>,
     pub c_1: Vec<u8>,
     #[serde(skip)]
-    pub _p: PhantomData<H>,
+    _p: PhantomData<H>,
+}
+
+impl<H> McElieceCiphertext<H> {
+    pub fn new(c_0: Vec<u8>, c_1: Vec<u8>) -> Self {
+        Self {
+            c_0,
+            c_1,
+            _p: PhantomData,
+        }
+    }
 }
 
 impl McElieceKEM65536PublicKey {


### PR DESCRIPTION
This PR enables usual (de)serialization of McEliece keys.

On the side, Gaussian elimination routine is slightly simplified. However, the efficiency is not improved unless a better algorithm can be adopted. More investigation is needed here.
Downstream crates need to cache the Gaussian elimination result as much as possible.

Blake2 was accidentally introduced as a dependency instead of a dev-dependency. This is rectified, too.
