### PR TITLE
Upgrade to RustCrypto 2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,15 +11,16 @@ alga_derive = "0.9.1"
 cached = "0.11.0"
 crossbeam = "0.7.3"
 derive_more = "0.15.0"
-digest = "0.8.0"
+digest = "0.9.0"
 failure = "0.1.0"
+generic-array = "0.14"
 lazy_static = "1.0"
 num = "0.2.0"
 rand = "0.7.2"
 rand_distr = "0.2.2"
 rayon = "1.3.0"
 serde_json = "1.0.0"
-sha2 = "0.8.0"
+sha2 = "0.9.0"
 structopt = "0.3.0"
 
 [dependencies.bitvec]
@@ -40,7 +41,7 @@ features = ["rayon"]
 
 [dev-dependencies]
 approx = "0.3.0"
-blake2 = "0.8.1"
+blake2 = "0.9.0"
 quickcheck = "0.8.0"
 quickcheck_macros = "0.8.0"
 rand_chacha = "0.2.1"

--- a/src/field.rs
+++ b/src/field.rs
@@ -350,11 +350,8 @@ impl AbstractMagma<Multiplicative> for GF2561D {
             (GF2561D(_), GF2561D(0)) => GF2561D(0),
             (GF2561D(left), GF2561D(right)) => {
                 let log = TABLES.log[left as usize] as u16 + TABLES.log[right as usize] as u16;
-                if log < 255 {
-                    GF2561D(TABLES.exp[log as usize])
-                } else {
-                    GF2561D(TABLES.exp[(log - 255) as usize])
-                }
+                let log = if log < 255 { log } else { log - 255 };
+                GF2561D(TABLES.exp[log as usize])
             }
         }
     }
@@ -372,8 +369,9 @@ impl TwoSidedInverse<Multiplicative> for GF2561D {
     fn two_sided_inverse(&self) -> Self {
         match *self {
             GF2561D(0) => panic!("divide by zero"),
+            GF2561D(1) => GF2561D(1),
             GF2561D(x) => {
-                let log = 255 - TABLES.log[x as usize] as u16;
+                let log = 255 - TABLES.log[x as usize];
                 GF2561D(TABLES.exp[log as usize])
             }
         }

--- a/src/lattice.rs
+++ b/src/lattice.rs
@@ -81,7 +81,7 @@ impl FiniteField for F {
 }
 
 lazy_static! {
-    static ref P273_2_72: Integer = { Integer::from(273) << 72 + 1 };
+    static ref P273_2_72: Integer = Integer::from(273) << 72 + 1;
 }
 
 pub type F = Fp<Prime273_72, Int, Int>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![type_length_limit = "2000000"]
+#![type_length_limit = "3000000"]
 
 #[cfg(test)]
 #[macro_use(quickcheck)]

--- a/src/mceliece.rs
+++ b/src/mceliece.rs
@@ -65,18 +65,18 @@ impl McElieceKEM65536PublicKey {
         let secret_bits = bitvec_to_u8(&secret);
         let c_1 = {
             let mut h = H::new();
-            h.input([2, 0]);
-            h.input(&secret_bits);
-            h.result().to_vec()
+            h.update([2, 0]);
+            h.update(&secret_bits);
+            h.finalize().to_vec()
         };
         let k = {
             let mut h = H::new();
-            h.input([1, 0]);
-            h.input(&secret_bits);
-            h.input(&c_0);
-            h.input([0]);
-            h.input(&c_1);
-            h.result()
+            h.update([1, 0]);
+            h.update(&secret_bits);
+            h.update(&c_0);
+            h.update([0]);
+            h.update(&c_1);
+            h.finalize()
         };
         (
             McElieceSessionKey(k.to_vec()),
@@ -119,21 +119,21 @@ where
 
         {
             let mut h = H::new();
-            h.input([2, 0]);
-            h.input(&secret_bits);
-            if h.result().to_vec() != c_1 {
+            h.update([2, 0]);
+            h.update(&secret_bits);
+            if h.finalize().to_vec() != c_1 {
                 secret_bits = vec![0];
                 b = 0;
             }
         };
         {
             let mut h = H::new();
-            h.input([b, 0]);
-            h.input(&secret_bits);
-            h.input(&c_0_);
-            h.input([0]);
-            h.input(&c_1);
-            McElieceSessionKey(h.result().to_vec())
+            h.update([b, 0]);
+            h.update(&secret_bits);
+            h.update(&c_0_);
+            h.update([0]);
+            h.update(&c_1);
+            McElieceSessionKey(h.finalize().to_vec())
         }
     }
 }

--- a/src/merkle.rs
+++ b/src/merkle.rs
@@ -565,10 +565,7 @@ where
 mod tests {
     use super::*;
 
-    use sha2::{
-        digest::{FixedOutput, Input},
-        Sha256,
-    };
+    use sha2::{digest::Digest, Sha256};
 
     #[derive(Debug)]
     struct MyHasher(u64);
@@ -577,21 +574,21 @@ mod tests {
         type Output = Vec<u8>;
         fn hash<S: Borrow<u8>>(&self, data: S) -> Self::Output {
             let mut d = Sha256::default();
-            d.input(self.0.to_le_bytes());
-            d.input(data.borrow().to_le_bytes());
-            d.fixed_result().into_iter().collect()
+            d.update(self.0.to_le_bytes());
+            d.update(data.borrow().to_le_bytes());
+            d.finalize().into_iter().collect()
         }
     }
     impl MerkleHash<(Vec<u8>, Vec<u8>)> for MyHasher {
         type Output = Vec<u8>;
         fn hash<S: Borrow<(Vec<u8>, Vec<u8>)>>(&self, data: S) -> Self::Output {
             let mut d = Sha256::default();
-            d.input(self.0.to_le_bytes());
+            d.update(self.0.to_le_bytes());
             let (a, b) = data.borrow();
-            d.input(a);
-            d.input(b", with another ");
-            d.input(b);
-            d.fixed_result().into_iter().collect()
+            d.update(a);
+            d.update(b", with another ");
+            d.update(b);
+            d.finalize().into_iter().collect()
         }
     }
 


### PR DESCRIPTION
Fortunately the interface changes in RustCrypto is at a manageable level. Bump to RustCrypto crates to 2.0 interface.